### PR TITLE
Improvement/add return type

### DIFF
--- a/src/Auth/LoginService.php
+++ b/src/Auth/LoginService.php
@@ -76,7 +76,7 @@ class LoginService
 
     /**
      * Cron에서 사용이 예상되면 isSessionableEnviroment() 호출하여 체크 후, 다른 이름을 사용해야한다.
-	 * @return string|null
+     * @return string|null
      */
     public static function GetAdminID()
     {

--- a/src/Auth/LoginService.php
+++ b/src/Auth/LoginService.php
@@ -76,6 +76,7 @@ class LoginService
 
     /**
      * Cron에서 사용이 예상되면 isSessionableEnviroment() 호출하여 체크 후, 다른 이름을 사용해야한다.
+	 * @return string|null
      */
     public static function GetAdminID()
     {


### PR DESCRIPTION
LoginService::GetAdminId() 함수의 PHPDoc return type이 없다 보니, 해당 함수의 리턴 결과가 IDE에서 항상 null로 잡혀, PHP type hinting을 이용하는 곳에서 해당 함수를 이용할 시 inspection 에러가 발생합니다. 그래서 리턴 타입을 추가했습니다.

