### PR TITLE
Use environment variables for the config.

### DIFF
--- a/src/Auth/AdminAuthService.php
+++ b/src/Auth/AdminAuthService.php
@@ -44,7 +44,13 @@ class AdminAuthService
             $menu_id_array[] = $menuid;
         }
 
-        if (\Config::$UNDER_DEV) {
+        if (class_exists('Config')) {
+            $is_dev = \Config::$UNDER_DEV;
+        } else {
+            $is_dev = $_ENV['DEBUG'];
+        }
+
+        if ($is_dev) {
             //개발 모드일 경우 모든 메뉴 id array 가져온다.
             $menuids_owned = $menu_id_array;
         } else {
@@ -278,7 +284,13 @@ class AdminAuthService
      */
     public static function hasUrlAuth($method = null, $check_url = null)
     {
-        if (!self::hasHashAuth($method, $check_url) && !\Config::$UNDER_DEV) {
+        if (class_exists('Config')) {
+            $is_dev = \Config::$UNDER_DEV;
+        } else {
+            $is_dev = $_ENV['DEBUG'];
+        }
+
+        if (!self::hasHashAuth($method, $check_url) && !$is_dev) {
             throw new \Exception("해당 권한이 없습니다.");
         }
     }

--- a/src/CmsApplication.php
+++ b/src/CmsApplication.php
@@ -24,7 +24,12 @@ class CmsApplication extends Application
 
     private function setDefaultErrorHandler()
     {
-        $this['debug'] = \Config::$UNDER_DEV;
+        if (class_exists('Config')) {
+            $this['debug'] = \Config::$UNDER_DEV;
+        } else {
+            $this['debug'] = $_ENV['debug'];
+        }
+
         $this->error(function (\Exception $e) {
             if ($this['debug']) {
                 return null;
@@ -83,24 +88,45 @@ class CmsApplication extends Application
 
     private function getTwigGlobalVariables()
     {
-        $globals = [
-            'FRONT_URL' => 'http://' . \Config::$DOMAIN,
-            'STATIC_URL' => '/admin/static',
-			'BOWER_PATH' => '/static/bower_components',
+        if (class_exists('Config')) {
+            $globals = [
+                'FRONT_URL' => 'http://' . \Config::$DOMAIN,
+                'STATIC_URL' => '/admin/static',
+                'BOWER_PATH' => '/static/bower_components',
 
-            'MISC_URL' => \Config::$MISC_URL,
-            'BANNER_URL' => \Config::$ACTIVE_URL . '/ridibooks_banner/',
-            'ACTIVE_URL' => \Config::$ACTIVE_URL,
-            'DM_IMAGE_URL' => \Config::$ACTIVE_URL . '/ridibooks_dm/',
+                'MISC_URL' => \Config::$MISC_URL,
+                'BANNER_URL' => \Config::$ACTIVE_URL . '/ridibooks_banner/',
+                'ACTIVE_URL' => \Config::$ACTIVE_URL,
+                'DM_IMAGE_URL' => \Config::$ACTIVE_URL . '/ridibooks_dm/',
 
-            'PHP_SELF' => $_SERVER['PHP_SELF'],
-            'REQUEST_URI' => $_SERVER['REQUEST_URI'],
+                'PHP_SELF' => $_SERVER['PHP_SELF'],
+                'REQUEST_URI' => $_SERVER['REQUEST_URI'],
 
-            "HTTP_HOST_LINK" => \Config::$HTTP_HOST_LINK,
-            "SSL_HOST_LINK" => \Config::$SSL_HOST_LINK,
+                "HTTP_HOST_LINK" => \Config::$HTTP_HOST_LINK,
+                "SSL_HOST_LINK" => \Config::$SSL_HOST_LINK,
 
-            'base_url' => \Config::$DOMAIN
-        ];
+                'base_url' => \Config::$DOMAIN
+            ];
+        } else {
+            $globals = [
+                'FRONT_URL' => 'http://' . $_ENV['DOMAIN'],
+                'STATIC_URL' => '/admin/static',
+                'BOWER_PATH' => '/static/bower_components',
+
+                'MISC_URL' => $_ENV['MISC_URL'],
+                'BANNER_URL' => $_ENV['ACTIVE_URL'] . '/ridibooks_banner/',
+                'ACTIVE_URL' => $_ENV['ACTIVE_URL'],
+                'DM_IMAGE_URL' => $_ENV['ACTIVE_URL'] . '/ridibooks_dm/',
+
+                'PHP_SELF' => $_SERVER['PHP_SELF'],
+                'REQUEST_URI' => $_SERVER['REQUEST_URI'],
+
+                "HTTP_HOST_LINK" => $_ENV['HTTP_HOST_LINK'],
+                "SSL_HOST_LINK" => $_ENV['SSL_HOST_LINK'],
+
+                'base_url' => $_ENV['DOMAIN']
+            ];
+        }
 
         if (isset($_SESSION['session_user_menu'])) {
             $globals['session_user_menu'] = $_SESSION['session_user_menu'];


### PR DESCRIPTION
## 배경
cms-admin을 Dockerize하는 작업 중입니다. Docker에서 config값을 환경변수로 전달하는 것이 보편적이어서 전역 Config클래스를 제거하고 dotenv를 사용하도록 변경하고 있습니다.

## 변경점
cms-admin에서 전역Config를 제거하려면 cms-sdk도 전역Config를 사용하지 않도록 변경해야 합니다. 다른 서비스를 고려해서 Config클래스를 찾지 못한 경우에만 환경변수를 참조하도록 만들었습니다.


원론적으로는 cms-sdk가 직접 config를 참조하는 부분은 전부 제거해야 한다고 생각합니다. 그러려면 cms-sdk를 사용하는  곳에서 config값을 전달받아야하는데, 관련 서비스를 전부 수정해야 하므로 일단 환경변수만 지원하도록 변경했습니다.