### PR TITLE
Added PATH_INFO to twig global variable, and used in menu list.

### DIFF
--- a/src/CmsApplication.php
+++ b/src/CmsApplication.php
@@ -100,6 +100,7 @@ class CmsApplication extends Application
                 'DM_IMAGE_URL' => \Config::$ACTIVE_URL . '/ridibooks_dm/',
 
                 'PHP_SELF' => $_SERVER['PHP_SELF'],
+                'PATH_INFO' => strtok($_SERVER["REQUEST_URI"],'?'),
                 'REQUEST_URI' => $_SERVER['REQUEST_URI'],
 
                 "HTTP_HOST_LINK" => \Config::$HTTP_HOST_LINK,
@@ -119,6 +120,7 @@ class CmsApplication extends Application
                 'DM_IMAGE_URL' => $_ENV['ACTIVE_URL'] . '/ridibooks_dm/',
 
                 'PHP_SELF' => $_SERVER['PHP_SELF'],
+                'PATH_INFO' => strtok($_SERVER["REQUEST_URI"],'?'),
                 'REQUEST_URI' => $_SERVER['REQUEST_URI'],
 
                 "HTTP_HOST_LINK" => $_ENV['HTTP_HOST_LINK'],

--- a/src/CmsApplication.php
+++ b/src/CmsApplication.php
@@ -100,8 +100,8 @@ class CmsApplication extends Application
                 'DM_IMAGE_URL' => \Config::$ACTIVE_URL . '/ridibooks_dm/',
 
                 'PHP_SELF' => $_SERVER['PHP_SELF'],
-                'PATH_INFO' => explode('?', $_SERVER['REQUEST_URI'])[0],
                 'REQUEST_URI' => $_SERVER['REQUEST_URI'],
+                'REQUEST_PATH' => explode('?', $_SERVER['REQUEST_URI'])[0],
 
                 "HTTP_HOST_LINK" => \Config::$HTTP_HOST_LINK,
                 "SSL_HOST_LINK" => \Config::$SSL_HOST_LINK,
@@ -120,8 +120,8 @@ class CmsApplication extends Application
                 'DM_IMAGE_URL' => $_ENV['ACTIVE_URL'] . '/ridibooks_dm/',
 
                 'PHP_SELF' => $_SERVER['PHP_SELF'],
-                'PATH_INFO' => explode('?', $_SERVER['REQUEST_URI'])[0],
                 'REQUEST_URI' => $_SERVER['REQUEST_URI'],
+                'REQUEST_PATH' => explode('?', $_SERVER['REQUEST_URI'])[0],
 
                 "HTTP_HOST_LINK" => $_ENV['HTTP_HOST_LINK'],
                 "SSL_HOST_LINK" => $_ENV['SSL_HOST_LINK'],

--- a/src/CmsApplication.php
+++ b/src/CmsApplication.php
@@ -100,7 +100,7 @@ class CmsApplication extends Application
                 'DM_IMAGE_URL' => \Config::$ACTIVE_URL . '/ridibooks_dm/',
 
                 'PHP_SELF' => $_SERVER['PHP_SELF'],
-                'PATH_INFO' => strtok($_SERVER["REQUEST_URI"],'?'),
+                'PATH_INFO' => explode('?', $_SERVER['REQUEST_URI'])[0],
                 'REQUEST_URI' => $_SERVER['REQUEST_URI'],
 
                 "HTTP_HOST_LINK" => \Config::$HTTP_HOST_LINK,
@@ -120,7 +120,7 @@ class CmsApplication extends Application
                 'DM_IMAGE_URL' => $_ENV['ACTIVE_URL'] . '/ridibooks_dm/',
 
                 'PHP_SELF' => $_SERVER['PHP_SELF'],
-                'PATH_INFO' => strtok($_SERVER["REQUEST_URI"],'?'),
+                'PATH_INFO' => explode('?', $_SERVER['REQUEST_URI'])[0],
                 'REQUEST_URI' => $_SERVER['REQUEST_URI'],
 
                 "HTTP_HOST_LINK" => $_ENV['HTTP_HOST_LINK'],

--- a/views/comm/left_menu_new.twig
+++ b/views/comm/left_menu_new.twig
@@ -30,13 +30,13 @@
         {% endif %}
       {% endif %}
 
-      {% if PATH_INFO == menu.menu_url %}
+      {% if REQUEST_PATH == menu.menu_url %}
         <li class="active">
       {% else %}
         <li
         {# TODO AuthService refactoring 할때 고려할 것(실제로 menu에 사용되는 data만 내려줄 것) #}
         {% for ajax in menu.ajax_array %}
-          {% if PATH_INFO == ajax.ajax_url %}
+          {% if REQUEST_PATH == ajax.ajax_url %}
             class="active"
           {% endif %}
         {% endfor %}
@@ -60,7 +60,7 @@
   {% endfor %}
   {% endif %}
   <ul class="nav nav-pills nav-stacked" style="padding-left: 15px;">
-    {% if PATH_INFO == '/me' %}
+    {% if REQUEST_PATH == '/me' %}
     <li class="active">
   {% else %}
     <li>
@@ -68,7 +68,7 @@
       <a href="/me">개인정보 수정</a>
     </li>
 
-    {% if PATH_INFO == '/logout' %}
+    {% if REQUEST_PATH == '/logout' %}
     <li class="active">
       {% else %}
     <li>

--- a/views/comm/left_menu_new.twig
+++ b/views/comm/left_menu_new.twig
@@ -34,7 +34,7 @@
         <li class="active">
       {% else %}
         <li
-         TODO AuthService refactoring 할때 고려할 것(실제로 menu에 사용되는 data만 내려줄 것)
+        {# TODO AuthService refactoring 할때 고려할 것(실제로 menu에 사용되는 data만 내려줄 것) #}
         {% for ajax in menu.ajax_array %}
           {% if PATH_INFO == ajax.ajax_url %}
             class="active"

--- a/views/comm/left_menu_new.twig
+++ b/views/comm/left_menu_new.twig
@@ -30,13 +30,13 @@
         {% endif %}
       {% endif %}
 
-      {% if REQUEST_URI starts with menu.menu_url %}
+      {% if PATH_INFO == menu.menu_url %}
         <li class="active">
       {% else %}
         <li
-        {# TODO AuthService refactoring 할때 고려할 것(실제로 menu에 사용되는 data만 내려줄 것) #}
+         TODO AuthService refactoring 할때 고려할 것(실제로 menu에 사용되는 data만 내려줄 것)
         {% for ajax in menu.ajax_array %}
-          {% if REQUEST_URI starts with ajax.ajax_url %}
+          {% if PATH_INFO == ajax.ajax_url %}
             class="active"
           {% endif %}
         {% endfor %}
@@ -60,7 +60,7 @@
   {% endfor %}
   {% endif %}
   <ul class="nav nav-pills nav-stacked" style="padding-left: 15px;">
-    {% if REQUEST_URI starts with '/me' %}
+    {% if PATH_INFO == '/me' %}
     <li class="active">
   {% else %}
     <li>
@@ -68,7 +68,7 @@
       <a href="/me">개인정보 수정</a>
     </li>
 
-    {% if REQUEST_URI starts with '/logout' %}
+    {% if PATH_INFO == '/logout' %}
     <li class="active">
       {% else %}
     <li>


### PR DESCRIPTION
https://app.asana.com/0/235684600038401/367149639264054/f
(메뉴 리스트에서 지금 페이지가 어떤 메뉴인지 찾아 active를 set하는 부분 - REQUST_URI와 start with를 사용해서 발생하는 버그)

위 이슈랑 관련해서 twig global에 PATH_INFO를 추가했습니다.

실제 $_SERVER['PATH_INFO']는 값이 없는 경우도 있기 때문에 바로 사용하지 않고 $_SERVER['REQUSET_URI']에서 query string을 지운 값을 넣었습니다.

혹시 더 좋은 아이디어가 있다면 말씀해주세요.