### PR TITLE
Use Config at SESSION_TIMEOUT_SEC

### DIFF
--- a/src/Auth/LoginService.php
+++ b/src/Auth/LoginService.php
@@ -102,14 +102,16 @@ class LoginService
 
     public static function startSession()
     {
-        session_set_cookie_params(self::SESSION_TIMEOUT_SEC, '/', $_SERVER['SERVER_NAME']);
+        $session_lifetime = defined('\Config::SESSION_TIMEOUT_SEC') ? \Config::SESSION_TIMEOUT_SEC : self::SESSION_TIMEOUT_SEC;
+        session_set_cookie_params($session_lifetime, '/', $_SERVER['SERVER_NAME']);
         session_start();
     }
 
     public static function startCouchbaseSession($server_hosts)
     {
+        $session_lifetime = defined('\Config::SESSION_TIMEOUT_SEC') ? \Config::SESSION_TIMEOUT_SEC : self::SESSION_TIMEOUT_SEC;
         session_set_save_handler(
-            new CouchbaseSessionHandler(implode(',', $server_hosts), 'session', self::SESSION_TIMEOUT_SEC),
+            new CouchbaseSessionHandler(implode(',', $server_hosts), 'session', $session_lifetime),
             true
         );
 


### PR DESCRIPTION
### 변경:
session lifetime 설정 시, `Config::SESSION_TIMEOUT_SEC`가 정의된 경우 그 값을 사용하도록 변경했습니다. (없으면 기존대로 12시간을 default값으로 사용합니다.)

### 의도:
session lifetime 추후 변경 시 cms-sdk 변경, 배포 없이 config 수정만으로 변경이 가능하도록 합니다.
